### PR TITLE
Update link to Phoenix guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ready to run in production? Please [check our deployment guides](http://www.phoe
 ## Learn more
 
   * Official website: http://www.phoenixframework.org/
-  * Guides: http://phoenixframework.org/docs/overview
+  * Guides: https://hexdocs.pm/phoenix/overview.html
   * Docs: https://hexdocs.pm/phoenix
   * Mailing list: http://groups.google.com/group/phoenix-talk
   * Source: https://github.com/phoenixframework/phoenix


### PR DESCRIPTION
Working through this getting started guide today, I discovered that the link to the Phoenix guides page returned a 404. This patch updates the link to what I believe is the [current URL](https://hexdocs.pm/phoenix/overview.html).