### PR TITLE
Wait for review app dbs to be available

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ deploy_review:
     - gigalixir create --name $APP_NAME || gigalixir git:remote $APP_NAME
     - echo "Creating database"
     - if [ "$(gigalixir pg -a $APP_NAME)" = "[]" ]; then gigalixir pg:create -a $APP_NAME; fi
+    - while true; do if [[ `gigalixir pg -a $APP_NAME | grep AVAILABLE | wc -l` == 1 ]]; then break; fi; sleep 2; done
     - echo "Pushing"
     - git push -f gigalixir HEAD:refs/heads/master
     - echo "Databases may take some time to create. You can check the status by running gigalixir pg -a $APP_NAME"


### PR DESCRIPTION
This change will make the deploy wait for the review app db to become available before continuing as the push will fail with a DATABASE_URL is missing if the db takes more than a few seconds to setup.